### PR TITLE
Extend update to dump final mbtiles to target and add cron example

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,29 @@
-# ZIP_URL="https://example.com/netex/stops.zip"
-# ZIP_FILE="./build/stops.zip"
-# OUTPUT_GEOJSON="./build/stops.geojson"
-# OUTPUT_MBTILES="./build/stops.mbtiles"
-# FORCE_MB=1
-# DELETE_INTERIM=0
+# -*- mode: shell-script; -*-
+#
+# URL containing zipped stop places in NeTEx format.
+# This instance is all active stops in Norway
+#ZIP_URL="https://example.com/netex/stops.zip"
+
+# Target of downloaded zip.
+#ZIP_FILE="./build/stops.zip"
+
+# Target of generated geojson.
+#OUTPUT_GEOJSON="./build/stops.geojson"
+
+# Target of mbtiles file during generation.
+#OUTPUT_MBTILES="./build/stops.mbtiles"
+
+# Set to 1 to force overwrite existing mbtiles file.
+#FORCE_MB=1
+
+# When generation is complete and mbtiles is successfully created, set this to
+# the final destination where the tile should reside. This will replace existing
+# mbtile if `FORCE_MB` is set.
+#
+# TARGET_MBTILE="/var/www/martin/tiles/stops_norway.mbtile"
+#TARGET_MBTILE=""
+
+# Set to 1 if downladed and temporarily generated files files should be deleted
+# after successful tile generation. If TARGET_MBTILE is set, the OUTPUT_MBTILES
+# file will also be deleted as this then is considered interim.
+#DELETE_INTERIM=0

--- a/etc/cron.d/stops-to-tiles
+++ b/etc/cron.d/stops-to-tiles
@@ -1,3 +1,14 @@
 # Example cron.d config for copying generated stop tiles to tile server.
 
-30 5 * * * www-data /path/to/stopstotiles/update-stop-tiles.sh && systemctl restart martin
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+SHELL=/usr/bin/bash
+
+S2T_HOME=/path/to/stopstotiles
+# RUNAS=www-data
+
+# System services need to be restarted by root-ish users.
+30 5 * * * root $S2T_HOME/update-stop-tiles.sh && systemctl restart martin
+
+# Set this if running as configured user. This does not require elevated
+# privileges.
+#30 5 * * * $RUN_AS $S2T_HOME/update-stop-tiles.sh

--- a/etc/cron.d/stops-to-tiles
+++ b/etc/cron.d/stops-to-tiles
@@ -1,0 +1,3 @@
+# Example cron.d config for copying generated stop tiles to tile server.
+
+30 5 * * * www-data /path/to/stopstotiles/update-stop-tiles.sh && systemctl restart martin

--- a/update-stop-tiles.sh
+++ b/update-stop-tiles.sh
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
 
 #
-# Default configuration. Override by copying .env-example to .env
-#
-# URL containing zipped stop places in NeTEx format.
-# This instance is all active stops in Norway
+# Default configuration. Override by copying .env-example to .env and adjust
+# values there.  See .env-example for explanation
+
 ZIP_URL="https://storage.googleapis.com/marduk-production/tiamat/Current_latest.zip"
-
-# Target of downloaded zip.
 ZIP_FILE="./build/stops.zip"
-
-# Target of generated geojson.
 OUTPUT_GEOJSON="./build/stops.geojson"
-
-# Target of final mbtiles file.
 OUTPUT_MBTILES="./build/stops.mbtiles"
-
-# Set to 1 to force overwrite existing mbtiles file.
 FORCE_MB=1
-
-# Set to 1 if downladed (zip) and temporarily generated files (geojson) files
-# should be deleted after successful tile generation
+TARGET_MBTILE=""
 DELETE_INTERIM=0
 
 cd $(dirname $0)
@@ -38,7 +27,7 @@ run_converter() {
     local cmd="$PHP_CONVERTER --input $1 --output $2"
     if [ -n "$3" ]; then
         cmd="$cmd --mbtiles $3"
-        if [[ $((FORVE_MB)) ]]; then
+        if (( FORCE_MB > 0 )); then
             cmd="$cmd --force"
         fi
     fi
@@ -48,7 +37,21 @@ run_converter() {
 download_file "$ZIP_URL" "$ZIP_FILE"
 run_converter "$ZIP_FILE" "$OUTPUT_GEOJSON" "$OUTPUT_MBTILES"
 
-if [[ $((DELETE_INTERIM)) > 0 ]]; then
-    rm -f $ZIP_FILE
-    rm -f $OUTPUT_GEOJSON
+if (( DELETE_INTERIM > 0 )); then
+    rm -fv $ZIP_FILE
+    rm -fv $OUTPUT_GEOJSON
+fi
+
+CP_OPTS="-v"
+if (( FORCE_MB > 0 )); then
+    CP_OPTS="$CP_OPTS -f"
+else
+    CP_OPTS="$CP_OPTS --update=none"
+fi
+
+if [[ -n $TARGET_MBTILE ]]; then
+    cp $CP_OPTS $OUTPUT_MBTILES $TARGET_MBTILE
+    if (( DELETE_INTERIM > 0 )); then
+        rm -fv $OUTPUT_MBTILES
+    fi
 fi


### PR DESCRIPTION
Title says it all.

Brown paper bag fixes here too. The last commit had non-working checks for variable state.

The update script is extended to copy the final generated mbtiles to a destination folder, and an example cron entry is provided. This needs to be adjusted, of course, on a per installation basis.