### PR TITLE
Supplement stop tile data with additional quay meta

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -13,6 +13,9 @@
 # Target of mbtiles file during generation.
 #OUTPUT_MBTILES="./build/stops.mbtiles"
 
+# Force re-download of existing zip file even if it's recent.
+#FORCE_DL=0
+
 # Set to 1 to force overwrite existing mbtiles file.
 #FORCE_MB=1
 

--- a/src/NetexParser.php
+++ b/src/NetexParser.php
@@ -119,7 +119,7 @@ class NetexParser
         // Magic numer 12 = default zoom
         $minzoom = $this->layerMinZoom[$stopPlaceLayer] ?? 12;
         $stopProperties = [
-            "type" => "StopPlace",
+            "type" => "stopPlace",
             "id"   => $id,
             "name" => (string)$place->children($this->ns['n'])->Name,
             "transportMode" => $transportMode,
@@ -153,7 +153,9 @@ class NetexParser
         $centroid = $quay->children($this->ns['n'])->Centroid->children($this->ns['n'])->Location;
         $lat = (float)($centroid->children($this->ns['n'])->Latitude ?? 0);
         $lon = (float)($centroid->children($this->ns['n'])->Longitude ?? 0);
-        // $publicCode = (string) $quay->children($this->ns['n'])->Centroid->children($this->ns['n'])->Location
+        $publicCode = (string)$quay->children($this->ns['n'])->PublicCode;
+        $privateCode = (string)$quay->children($this->ns['n'])->PrivateCode;
+        $compassBearing = (float)$quay->children($this->ns['n'])->CompassBearing;
 
         if (!$lat || !$lon) {
             return [];
@@ -164,8 +166,11 @@ class NetexParser
             "geometry" => ["type" => "Point", "coordinates" => [$lon, $lat]],
             "tippecanoe" => ["layer" => "quays", "minzoom" => $this->layerMinZoom['quays']],
             "properties" => [
-                "type" => "Quay",
+                "type" => "quay",
                 "id"   => $id,
+                "publicCode" => $publicCode,
+                "privateCode" => $privateCode,
+                "compassBearing" => $compassBearing,
                 "parentStopPlaceId" => $stopProperties["id"],
                 "transportMode" => $stopProperties["transportMode"],
                 "stopPlaceType" => $stopProperties["stopPlaceType"],

--- a/src/NetexParser.php
+++ b/src/NetexParser.php
@@ -113,28 +113,30 @@ class NetexParser
         $stopPlaceLayer = $this->layers[$type] ?? "minor";
         $transportMode = (string)$place->children($this->ns['n'])->TransportMode;
 
-        if ($lat && $lon) {
-            // Magic numer 12 = default zoom
-            $minzoom = $this->layerMinZoom[$stopPlaceLayer] ?? 12;
-            $features[] = [
-                "type" => "Feature",
-                "geometry" => ["type" => "Point", "coordinates" => [$lon, $lat]],
-                "tippecanoe" => ["layer" => $stopPlaceLayer, "minzoom" => $minzoom],
-                "properties" => [
-                    "type" => "StopPlace",
-                    "id"   => $id,
-                    "name" => (string)$place->children($this->ns['n'])->Name,
-                    "transportMode" => $transportMode,
-                    "stopPlaceType" => $type,
-                    "stopPlaceCategory" => $stopPlaceCategory,
-                ],
-            ];
+        if (!$lat || !$lon) {
+            return [];
         }
+        // Magic numer 12 = default zoom
+        $minzoom = $this->layerMinZoom[$stopPlaceLayer] ?? 12;
+        $stopProperties = [
+            "type" => "StopPlace",
+            "id"   => $id,
+            "name" => (string)$place->children($this->ns['n'])->Name,
+            "transportMode" => $transportMode,
+            "stopPlaceType" => $type,
+            "stopPlaceCategory" => $stopPlaceCategory,
+        ];
+        $features[] = [
+            "type" => "Feature",
+            "geometry" => ["type" => "Point", "coordinates" => [$lon, $lat]],
+            "tippecanoe" => ["layer" => $stopPlaceLayer, "minzoom" => $minzoom],
+            "properties" => $stopProperties,
+        ];
 
         $quaysNode = $place->children($this->ns['n'])->quays ?? null;
         if ($quaysNode) {
             foreach ($quaysNode->children($this->ns['n'])->Quay ?? [] as $quay) {
-                foreach ($this->parseQuay($quay, $id) as $qf) {
+                foreach ($this->parseQuay($quay, $stopProperties) as $qf) {
                     $features[] = $qf;
                 }
             }
@@ -143,7 +145,7 @@ class NetexParser
         return $features;
     }
 
-    private function parseQuay(SimpleXMLElement $quay, string $parentId): array
+    private function parseQuay(SimpleXMLElement $quay, array $stopProperties = []): array
     {
         $attrs = $quay->attributes();
         $id = (string)($attrs['id'] ?? '');
@@ -151,6 +153,7 @@ class NetexParser
         $centroid = $quay->children($this->ns['n'])->Centroid->children($this->ns['n'])->Location;
         $lat = (float)($centroid->children($this->ns['n'])->Latitude ?? 0);
         $lon = (float)($centroid->children($this->ns['n'])->Longitude ?? 0);
+        // $publicCode = (string) $quay->children($this->ns['n'])->Centroid->children($this->ns['n'])->Location
 
         if (!$lat || !$lon) {
             return [];
@@ -163,7 +166,10 @@ class NetexParser
             "properties" => [
                 "type" => "Quay",
                 "id"   => $id,
-                "parentStopPlaceId" => $parentId,
+                "parentStopPlaceId" => $stopProperties["id"],
+                "transportMode" => $stopProperties["transportMode"],
+                "stopPlaceType" => $stopProperties["stopPlaceType"],
+                "stopPlaceCategory" => $stopProperties["stopPlaceCategory"],
             ],
         ]];
     }

--- a/update-stop-tiles.sh
+++ b/update-stop-tiles.sh
@@ -9,8 +9,12 @@ ZIP_FILE="./build/stops.zip"
 OUTPUT_GEOJSON="./build/stops.geojson"
 OUTPUT_MBTILES="./build/stops.mbtiles"
 FORCE_MB=1
+FORCE_DL=0
 TARGET_MBTILE=""
 DELETE_INTERIM=0
+# Don't download zip file if it's more recent than these many seconds.
+# 60 * 60 * 8 = 28800
+MIN_AGE=28800
 
 cd $(dirname $0)
 set -e
@@ -20,7 +24,12 @@ fi
 
 PHP_CONVERTER="./convert.php"
 download_file() {
-    curl -L -o "$2" "$1" || { echo "Download failed!"; exit 1; }
+    if [[ ! -f $ZIP_FILE ]] ||
+       [[ $FORCE_DL -gt 0 ]] ||
+       [[ $(($(date +%s) - $(date -r $ZIP_FILE +%s))) -gt $MIN_AGE ]]
+    then
+        curl -L -o "$2" "$1"
+    fi
 }
 
 run_converter() {


### PR DESCRIPTION
Like
- `publicCode`
- `privateCode` (used a bit more widely than publicCode)
- `compassBearing` intended use is to indicate direction of departure for given quay.

Related to tromsfylkestrafikk/rtm#118